### PR TITLE
feat: wolf-waitからwolf-gameへのパスを繋ぐ

### DIFF
--- a/pages/wolf-game.tsx
+++ b/pages/wolf-game.tsx
@@ -1,0 +1,14 @@
+import type { NextPage } from "next";
+import React from "react";
+
+import { Text } from "@chakra-ui/react";
+
+const WolfGame: NextPage = () => {
+  return (
+    <>
+      <Text fontSize={24}>wolf-game</Text>
+    </>
+  );
+};
+
+export default WolfGame;

--- a/pages/wolf-wait.tsx
+++ b/pages/wolf-wait.tsx
@@ -1,4 +1,5 @@
 import type { NextPage } from "next";
+import router from "next/router";
 import React from "react";
 
 import { Button, Center, Text, VStack } from "@chakra-ui/react";
@@ -16,6 +17,10 @@ const WolfWait: NextPage = () => {
     { nickname: "ふかめも", particIcon: 3, point: 2 },
     { nickname: "KJ", particIcon: 4, point: 3 },
   ];
+
+  const handleGameStart = () => {
+    router.push("/wolf-game");
+  };
   return (
     <>
       <PageBackIcon pass={"/start-game"} />
@@ -28,7 +33,12 @@ const WolfWait: NextPage = () => {
           <Text fontSize={24}>メンバー：現在のポイント</Text>
           <PointList memberPointList={examplePointList} />
           <VSpacer size={4} />
-          <Button h={"60px"} w={"270px"} colorScheme="blue">
+          <Button
+            h={"60px"}
+            w={"270px"}
+            colorScheme="blue"
+            onClick={handleGameStart}
+          >
             ゲーム開始
           </Button>
         </VStack>


### PR DESCRIPTION
## 🔨 変更内容

- wolf-waitからwolf-gameへのパスを繋ぐ

## 📸 スクリーンショット

## 📢 この PR に含まないこと

- wolf-gameのUI
- ルーム作成者のみゲームスタートのボタンを押せるようにする

## 💡 レビューの観点

### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] CI/CD がすべて pass している
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー
- [ ] パスがつながっていることを確認

## ✅ 解決するイシュー

- close #170 

## 🤝 関連するイシュー

- #170 
